### PR TITLE
Fix the name "Taiwan" from "Taiwan, Province of China"

### DIFF
--- a/country.ts
+++ b/country.ts
@@ -204,7 +204,7 @@ export const countries = [
   { "code": "se", "name": " Sweden ", "flag": "🇸🇪" },
   { "code": "ch", "name": " Switzerland ", "flag": "🇨🇭" },
   { "code": "sy", "name": " Syrian Arab Republic ", "flag": "🇸🇾" },
-  { "code": "tw", "name": " Taiwan, Province of China ", "flag": "🇹🇼" },
+  { "code": "tw", "name": " Taiwan ", "flag": "🇹🇼" },
   { "code": "tj", "name": " Tajikistan ", "flag": "🇹🇯" },
   { "code": "tz", "name": " Tanzania, United Republic of ", "flag": "🇹🇿" },
   { "code": "th", "name": " Thailand ", "flag": "🇹🇭" },


### PR DESCRIPTION
I believe the term "Taiwan, Province of China" is from ISO 3166-1, but there are reasons not to use the term.

Reason for the PR:

0. See the Wikipedia article ["Taiwan, China"](https://en.wikipedia.org/wiki/Taiwan,_China) and the explanation in [菜市場政治學 (Chinese)](https://whogovernstw.org/2015/11/09/yenlunchang1) for the details of "Taiwan, Province of China" and ISO 3166-1.
1. The "region" field in [Google advanced search](https://www.google.com/advanced_search) -- where the API comes from -- is simply "Taiwan", not "Taiwan, Province of China".
2. In other software projects, "Taiwan" is a more acceptable option: [material-ui](https://github.com/mui/material-ui/pull/39729), [FreeBSD](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=138672)
3. The term "Taiwan, Province of China" is highly controversial and the Taiwanese government objected to the term, see [a question of the term on webmasters](https://webmasters.stackexchange.com/a/25254), [The Taipei Times](https://www.taipeitimes.com/News/front/archives/2019/11/08/2003725454), [Rti (Chinese)](https://www.rti.org.tw/news/view/id/2040682)


